### PR TITLE
Fix `wdio-electron-service` subpath import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@electron-forge/maker-squirrel": "^6.4.2",
         "@electron-forge/maker-zip": "^6.4.2",
         "@electron-forge/plugin-auto-unpack-natives": "^6.4.2",
+        "@types/electron-squirrel-startup": "^1.0.0",
         "@wdio/cli": "^8.17.0",
         "@wdio/local-runner": "^8.17.0",
         "@wdio/mocha-framework": "^8.17.0",
@@ -1191,6 +1192,12 @@
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
       }
+    },
+    "node_modules/@types/electron-squirrel-startup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/electron-squirrel-startup/-/electron-squirrel-startup-1.0.0.tgz",
+      "integrity": "sha512-Uq1VCzEwpVj7HrPfjTzfKwQtoZxiqrKLjrxqOm1UEu9aYXhiJkSB8z8eVi7fSriWo7odqREX9xb16YhepaSTYg==",
+      "dev": true
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@electron-forge/maker-squirrel": "^6.4.2",
     "@electron-forge/maker-zip": "^6.4.2",
     "@electron-forge/plugin-auto-unpack-natives": "^6.4.2",
+    "@types/electron-squirrel-startup": "^1.0.0",
     "@wdio/cli": "^8.17.0",
     "@wdio/local-runner": "^8.17.0",
     "@wdio/mocha-framework": "^8.17.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,8 @@
     "allowUnreachableCode": false,
     "declaration": false,
     "experimentalDecorators": true,
-    "lib": [
-      "dom",
-      "es2020"
-    ],
-    "moduleResolution": "node",
-    "module": "esnext",
+    "lib": ["dom", "es2020"],
+    "module": "NodeNext",
     "target": "es2020",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -18,10 +14,6 @@
     "jsxFragmentFactory": "Fragment",
     "skipLibCheck": true
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Node ignores the `exports` field of package.json if the wrong moduleResolution is used.  This should be documented in the service if we can't find a way to make these imports work with different moduleResolution values.

https://www.typescriptlang.org/tsconfig#moduleResolution
https://www.typescriptlang.org/tsconfig#node16nodenext-nightly-builds

Also added the typedefs for `electron-squirrel-startup`.